### PR TITLE
Fix smever parsing for x.x versions

### DIFF
--- a/versions/Version.go
+++ b/versions/Version.go
@@ -32,22 +32,40 @@ func ParseSemver(versionLiteral string) (Semver, error) {
 
 	versionParts := strings.Split(GetVersionPart(versionLiteral), ".")
 	if len(versionParts) != 3 {
-		return Semver{}, ErrInvalidVersionParts
-	}
+		if len(versionParts) == 2 {
+			for i, part := range versionParts {
+				parsed, err := strconv.Atoi(part)
+				if err != nil {
+					return Semver{}, ErrInvalidVersionParts
+				}
 
-	for i, part := range versionParts {
-		parsed, err := strconv.Atoi(part)
-		if err != nil {
+				switch i {
+				case 0:
+					semver.Major = parsed
+				case 1:
+					semver.Minor = parsed
+				}
+
+				semver.Patch = 0
+			}
+		} else {
 			return Semver{}, ErrInvalidVersionParts
 		}
+	} else {
+		for i, part := range versionParts {
+			parsed, err := strconv.Atoi(part)
+			if err != nil {
+				return Semver{}, ErrInvalidVersionParts
+			}
 
-		switch i {
-		case 0:
-			semver.Major = parsed
-		case 1:
-			semver.Minor = parsed
-		case 2:
-			semver.Patch = parsed
+			switch i {
+			case 0:
+				semver.Major = parsed
+			case 1:
+				semver.Minor = parsed
+			case 2:
+				semver.Patch = parsed
+			}
 		}
 	}
 

--- a/versions/Version_test.go
+++ b/versions/Version_test.go
@@ -787,7 +787,7 @@ func TestVersionParsing(t *testing.T) {
 		},
 		{
 			VersionString:  "5.66",
-			ExpectedResult: Semver{}, // missing patch
+			ExpectedResult: Semver{Major: 5, Minor: 66, Patch: 0}, // missing patch
 		},
 
 		// Invalid [major, minor, patch] version parts


### PR DESCRIPTION
react-router was using the version "7.2" that was parsed as 0.0.0 instead of 7.2.0